### PR TITLE
Add i18n support for provider name localization

### DIFF
--- a/fuo_bilibili/i18n/__init__.py
+++ b/fuo_bilibili/i18n/__init__.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from fluent.runtime import FluentLocalization, FluentResourceLoader
+from feeluown.i18n import _DEFAULT_LOCALE
+
+_DIR = Path(__file__).parent
+_l10n = None
+
+def t(msg_id: str, **kwargs) -> str:
+    global _l10n
+    if _l10n is None:
+        loader = FluentResourceLoader(roots=[str(_DIR / "{locale}")])
+        _l10n = FluentLocalization(
+            locales=[_DEFAULT_LOCALE, "zh-CN", "en-US", "ja-JP"],
+            resource_ids=["provider.ftl"],
+            resource_loader=loader,
+        )
+    return _l10n.format_value(msg_id, kwargs)

--- a/fuo_bilibili/i18n/en-US/provider.ftl
+++ b/fuo_bilibili/i18n/en-US/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for Bilibili
+
+provider-name = Bilibili

--- a/fuo_bilibili/i18n/ja-JP/provider.ftl
+++ b/fuo_bilibili/i18n/ja-JP/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for Bilibili
+
+provider-name = ビリビリ

--- a/fuo_bilibili/i18n/zh-CN/provider.ftl
+++ b/fuo_bilibili/i18n/zh-CN/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for Bilibili
+
+provider-name = 哔哩哔哩

--- a/fuo_bilibili/provider.py
+++ b/fuo_bilibili/provider.py
@@ -33,6 +33,7 @@ from fuo_bilibili.model import BSearchModel, BSongModel, BPlaylistModel, BArtist
     BAlbumModel
 from fuo_bilibili.util import json_to_lrc_text
 from fuo_bilibili.login import load_user_cookies
+from .i18n import t
 
 logger = logging.getLogger(__name__)
 SEARCH_TYPE_MAP = {
@@ -680,7 +681,7 @@ class BilibiliProvider(AbstractProvider, ProviderV2, SupportsSongSimilar, Suppor
 
     @property
     def name(self):
-        return __alias__
+        return t('provider-name')
 
     def close(self):
         self._api.close()


### PR DESCRIPTION
### 本次 PR 为哔哩哔哩插件添加了国际化支持，将原有的硬编码名称替换为可翻译的字符串。

### 主要修改：

- 新增 i18n 模块：引入 fluent 库以支持多语言加载与解析。
- 添加翻译资源：新增 `zh-CN、en-US、ja-JP` 三种语言的 `provider.ftl` 文件，定义 `provider-name`。
- 更新代码逻辑：修改 `provider.py`，将 name 属性的返回值从硬编码的 `__alias__ = '哔哩哔哩'` 改为调用 `t('provider-name')` 实现动态翻译。