### PR TITLE
Fix Bilibili cookie login for fractional bcoin balance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: dist/

--- a/fuo_bilibili/api/schema/responses.py
+++ b/fuo_bilibili/api/schema/responses.py
@@ -226,7 +226,7 @@ class NavInfoResponse(BaseResponse):
             text: str
 
         class Wallet(BaseModel):
-            bcoin_balance: int  # B币
+            bcoin_balance: float  # B币
             coupon_balance: int  # 赠送B币数
 
         class Wbi(BaseModel):

--- a/tests/test_nav_info_response.py
+++ b/tests/test_nav_info_response.py
@@ -1,0 +1,37 @@
+from fuo_bilibili.api.schema.responses import NavInfoResponse
+
+
+def test_nav_info_response_accepts_current_wallet_and_level_types():
+    payload = {
+        "code": 0,
+        "message": "0",
+        "ttl": 1,
+        "data": {
+            "isLogin": True,
+            "face": "https://example.com/avatar.jpg",
+            "mid": 123456,
+            "uname": "tester",
+            "wallet": {
+                "bcoin_balance": 3.1,
+                "coupon_balance": 0,
+            },
+            "level_info": {
+                "current_level": 6,
+                "current_min": 0,
+                "current_exp": 100,
+                "next_exp": 28800,
+            },
+            "wbi_img": {
+                "img_url": "https://i0.hdslb.com/bfs/wbi/image.png",
+                "sub_url": "https://i0.hdslb.com/bfs/wbi/sub.png",
+            },
+        },
+    }
+
+    if hasattr(NavInfoResponse, "model_validate"):
+        response = NavInfoResponse.model_validate(payload)
+    else:
+        response = NavInfoResponse.parse_obj(payload)
+
+    assert response.data.wallet.bcoin_balance == 3.1
+    assert response.data.level_info.next_exp == 28800


### PR DESCRIPTION
## Summary
- accept fractional `wallet.bcoin_balance` values in `NavInfoResponse` so cookie login can parse the current Bilibili `nav` payload
- add a regression test covering current `wallet` and `level_info` payload types

## Test Plan
- `uv run pytest /Users/cosven/code/feeluown-bilibili/tests/test_nav_info_response.py -q`
- provider-level smoke check with a reproduced `nav` payload in the FeelUOwn environment
