### PR TITLE
Fix weekly detail parsing when short links are missing

### DIFF
--- a/fuo_bilibili/api/schema/responses.py
+++ b/fuo_bilibili/api/schema/responses.py
@@ -1015,8 +1015,8 @@ class WeeklyDetailResponse(BaseResponse):
             dynamic: str
             cid: int
             dimension: Dimension
-            short_link: str
-            short_link_v2: str
+            short_link: str = ""
+            short_link_v2: str = ""
             first_frame: str
             pub_location: str
             bvid: str

--- a/tests/test_weekly_detail_response.py
+++ b/tests/test_weekly_detail_response.py
@@ -1,0 +1,72 @@
+from datetime import timedelta
+
+from fuo_bilibili.api.schema.responses import WeeklyDetailResponse
+
+
+def test_weekly_detail_response_accepts_missing_short_links():
+    payload = {
+        "code": 0,
+        "message": "0",
+        "ttl": 1,
+        "data": {
+            "list": [
+                {
+                    "aid": 1,
+                    "videos": 1,
+                    "tid": 17,
+                    "tname": "单机游戏",
+                    "copyright": 1,
+                    "pic": "https://example.com/cover.jpg",
+                    "title": "weekly item",
+                    "duration": 123,
+                    "rights": {
+                        "bp": 0,
+                        "elec": False,
+                        "download": True,
+                        "movie": False,
+                        "pay": False,
+                        "hd5": True,
+                        "no_reprint": False,
+                        "autoplay": True,
+                        "ugc_pay": False,
+                        "is_cooperation": False,
+                        "ugc_pay_preview": False,
+                        "no_background": False,
+                        "arc_pay": False,
+                    },
+                    "owner": {
+                        "mid": 123,
+                        "name": "owner",
+                        "face": "https://example.com/face.jpg",
+                    },
+                    "stat": {
+                        "aid": 1,
+                        "view": 10,
+                        "danmaku": 2,
+                        "like": 3,
+                    },
+                    "dynamic": "",
+                    "cid": 456,
+                    "dimension": {
+                        "width": 1920,
+                        "height": 1080,
+                        "rotate": 0,
+                    },
+                    "first_frame": "https://example.com/frame.jpg",
+                    "pub_location": "",
+                    "bvid": "BV1xx411c7mD",
+                    "rcmd_reason": "",
+                }
+            ]
+        },
+    }
+
+    if hasattr(WeeklyDetailResponse, "model_validate"):
+        response = WeeklyDetailResponse.model_validate(payload)
+    else:
+        response = WeeklyDetailResponse.parse_obj(payload)
+
+    item = response.data.list[0]
+    assert item.short_link == ""
+    assert item.short_link_v2 == ""
+    assert item.duration == timedelta(seconds=123)


### PR DESCRIPTION
### Motivation
- Some Bilibili weekly detail items omit `short_link`/`short_link_v2`, causing model validation to fail; make the schema tolerant to missing fields.

### Description
- Default `short_link` and `short_link_v2` to empty strings in `WeeklyDetailResponse.WeeklyDetail` and add `tests/test_weekly_detail_response.py` to cover a payload missing those fields and to assert duration conversion.

### Testing
- `python -m compileall -q fuo_bilibili tests` succeeded (with an existing `SyntaxWarning` in `fuo_bilibili/danmaku2ass.py`).
- `git diff --check` passed.
- Running `pytest` could not be completed in this environment due to inability to fetch dependencies from PyPI / missing local package setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57591e25608321b73a050fc69282c8)